### PR TITLE
fix(qri_build/qri): adjustments to `GOCACHE` so that my machine can build the qri binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 qri_build/qri_*
 qri_build/webapp
+qri_build/electron
+qri_build/qri-*
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 qri_build/qri_*
+qri_build/webapp

--- a/qri_build/qri.go
+++ b/qri_build/qri.go
@@ -111,6 +111,13 @@ func BuildQri(platform, arch, qriRepoPath string) (path string, err error) {
 		return
 	}
 
+	// GOCACHE is a required env variable in order to build
+	// need to get the user's cache directory
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return
+	}
+
 	build := command{
 		String: "go build -o %s %s",
 		Tmpl: []interface{}{
@@ -124,6 +131,7 @@ func BuildQri(platform, arch, qriRepoPath string) (path string, err error) {
 			// TODO (b5): need this while we're still off go modules
 			"GOPATH":      os.Getenv("GOPATH"),
 			"GO111MODULE": "off",
+			"GOCACHE":     cacheDir,
 		},
 	}
 

--- a/qri_build/webapp.go
+++ b/qri_build/webapp.go
@@ -34,7 +34,7 @@ var WebappCmd = &cobra.Command{
 				log.Errorf("building webapp: %s", err)
 			}
 		}
-		if err := BuildWebapp(frontendPath, ipfsAdd); err != nil {
+		if err := BuildWebapp(frontendPath, readOnly, ipfsAdd); err != nil {
 			log.Errorf("building webapp: %s", err)
 		}
 	},

--- a/qri_build/webapp.go
+++ b/qri_build/webapp.go
@@ -29,11 +29,6 @@ var WebappCmd = &cobra.Command{
 			return
 		}
 
-		if readOnly {
-			if err := BuildWebappReadonly(frontendPath, ipfsAdd); err != nil {
-				log.Errorf("building webapp: %s", err)
-			}
-		}
 		if err := BuildWebapp(frontendPath, readOnly, ipfsAdd); err != nil {
 			log.Errorf("building webapp: %s", err)
 		}
@@ -72,52 +67,6 @@ func BuildWebapp(frontendPath string, readOnly, ipfsAdd bool) (err error) {
 	if readOnly {
 		webpackFile = "webpack.config.readonly.prod.js"
 	}
-
-	cmd := command{
-		String: "node --trace-warnings --require @babel/register %s --config %s --colors",
-		Tmpl: []interface{}{
-			"node_modules/webpack/bin/webpack",
-			webpackFile,
-		},
-		Dir: frontendPath,
-		Env: map[string]string{
-			"PATH":         path,
-			"NODE_ENV":     "production",
-			"NODE_OPTIONS": "--max_old_space_size=10000",
-		},
-	}
-
-	if err = cmd.Run(); err != nil {
-		return err
-	}
-
-	if err = move(outputPath, "./webapp"); err != nil {
-		return
-	}
-
-	if ipfsAdd {
-		hash, err := IPFSAdd("webapp")
-		if err != nil {
-			return err
-		}
-		log.Infof("ipfs hash: %s", hash)
-	}
-
-	return
-}
-
-// BuildWebappReadonly builds the webapp in readonly mode
-func BuildWebappReadonly(frontendPath string, ipfsAdd bool) (err error) {
-
-	// webpackPath := filepath.Join(frontendPath, "node_modules/webpack/bin/webpack")
-	outputPath := filepath.Join(frontendPath, "dist/readonly")
-
-	path, err := npmDoPath(frontendPath)
-	if err != nil {
-		return
-	}
-
-	webpackFile := "webpack.config.readonly.prod.js"
 
 	cmd := command{
 		String: "node --trace-warnings --require @babel/register %s --config %s --colors",


### PR DESCRIPTION
Need `GOCACHE` to be set in order to build the qri binary! fixes #1 

also adds patterns to ignore in the gitignore file

And also adds a missing `readOnly` param in the webapp build section.