### PR TITLE
feat(webapp api url): adds flag to give a specific api url the frontend should call to

### DIFF
--- a/qri_build/webapp.go
+++ b/qri_build/webapp.go
@@ -29,7 +29,13 @@ var WebappCmd = &cobra.Command{
 			return
 		}
 
-		if err := BuildWebapp(frontendPath, readOnly, ipfsAdd); err != nil {
+		apiURL, err := cmd.Flags().GetString("api-url")
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		if err := BuildWebapp(frontendPath, readOnly, ipfsAdd, apiURL); err != nil {
 			log.Errorf("building webapp: %s", err)
 		}
 	},
@@ -39,6 +45,7 @@ func init() {
 	WebappCmd.Flags().String("frontend", "frontend", "path to qri frontend repo")
 	WebappCmd.Flags().Bool("readonly", false, "build webapp in readonly mode")
 	WebappCmd.Flags().Bool("ipfs", false, "add completed build to local IPFS repo")
+	WebappCmd.Flags().String("api-url", "", "url the webapp should ping for the qri api")
 }
 
 // BuildWebapp builds the frontend and moves the result into a local directory
@@ -50,7 +57,7 @@ func init() {
 // 		./node_modules/webpack/bin/webpack
 // 			--config webpack.config.webapp.prod.js
 // 			--colors
-func BuildWebapp(frontendPath string, readOnly, ipfsAdd bool) (err error) {
+func BuildWebapp(frontendPath string, readOnly, ipfsAdd bool, apiURL string) (err error) {
 
 	// webpackPath := filepath.Join(frontendPath, "node_modules/webpack/bin/webpack")
 	outputPath := filepath.Join(frontendPath, "dist/web")
@@ -76,9 +83,10 @@ func BuildWebapp(frontendPath string, readOnly, ipfsAdd bool) (err error) {
 		},
 		Dir: frontendPath,
 		Env: map[string]string{
-			"PATH":         path,
-			"NODE_ENV":     "production",
-			"NODE_OPTIONS": "--max_old_space_size=10000",
+			"PATH":                       path,
+			"NODE_ENV":                   "production",
+			"NODE_OPTIONS":               "--max_old_space_size=10000",
+			"QRI_FRONTEND_BUILD_API_URL": apiURL,
 		},
 	}
 


### PR DESCRIPTION
When building the frontend webapp for `app.qri.io` we need the option of allowing a build that uses `api.qri.io` as the backend api, rather than `localhost:2503`.

This adds a flag `api-url` where you can specify the api url you need!